### PR TITLE
Add videos collection

### DIFF
--- a/src/collections/videos.ts
+++ b/src/collections/videos.ts
@@ -1,0 +1,74 @@
+import { CollectionConfig } from 'payload';
+import { commonSiteKeyField } from './commonSiteKeyField';
+import { optionalDisplayFields } from '../fields/optionalFields';
+import { timestampedFields } from '../fields/timestampedFields';
+
+const Videos: CollectionConfig = {
+  slug: 'videos',
+  admin: { useAsTitle: 'title' },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    commonSiteKeyField,
+    {
+      name: 'title',
+      label: 'Title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'description',
+      label: 'Description',
+      type: 'textarea',
+    },
+    {
+      name: 'cloudinaryPublicId',
+      label: 'Cloudinary Public ID',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'thumbnailUrl',
+      label: 'Thumbnail URL',
+      type: 'text',
+    },
+    {
+      name: 'orientation',
+      label: 'Orientation',
+      type: 'select',
+      options: [
+        {
+          label: 'Landscape',
+          value: 'landscape',
+        },
+        {
+          label: 'Portrait',
+          value: 'portrait',
+        },
+        {
+          label: 'Square',
+          value: 'square',
+        },
+      ],
+      defaultValue: 'landscape',
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'select',
+      options: [
+        { label: 'Draft', value: 'draft' },
+        { label: 'Published', value: 'published' },
+        { label: 'Archived', value: 'archived' },
+      ],
+      defaultValue: 'draft',
+      required: true,
+      admin: { position: 'sidebar' },
+    },
+    ...optionalDisplayFields,
+    ...timestampedFields,
+  ],
+};
+
+export default Videos;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -33,6 +33,7 @@ import LimitedTimeOffers from "./collections/limitedtimeoffers";
 import Locations from "./collections/locations";
 import Navigation from "./collections/navigation";
 import Team from "./collections/team";
+import Videos from "./collections/videos";
 import Ads from "./collections/ads";
 import Pages from "./collections/pages";
 import Blocks from "./collections/blocks";
@@ -68,6 +69,7 @@ export default buildConfig({
     FAQs,
     Gallery,
     LimitedTimeOffers,
+    Videos,
     Locations,
     Navigation,
     Team,


### PR DESCRIPTION
## Summary
- create `videos` collection for Cloudinary-hosted video data
- register the new collection in the Payload config

## Testing
- `npm run generate:types` *(fails: cross-env not found)*
- `npm run lint` *(fails: cross-env not found)*